### PR TITLE
Update designs.dm

### DIFF
--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -1943,11 +1943,16 @@ CIRCUITS BELOW
 // (TECH_MATERIAL = 2, TECH_ENGINEERING = 2, TECH_PHORON = 1, TECH_POWER = 3, TECH_BLUESPACE = 1, TECH_BIO = 1, TECH_COMBAT = 1, TECH_MAGNET = 4, TECH_DATA = 1, TECH_ILLEGAL = 1)
 
 /*
-Find out the cause of why the armor isn't in-game when able, I'm assuming it's to do with tech levels so relook at it later (remove this message when it's fixed)
-Please also work on allowing armor to be more mass-produced, the mechaincum should be making a majority of their stuff for the guard (armor/weapons/ammo)
 A reminder that mechanicus cannot remove their armor for a majority of their roles, so please do not add armor for them.
 */
 // ARMOR
+/datum/design/armor
+	build_type = PROTOLATHE
+
+/datum/design/armor/AssembleDesignName()
+	..()
+	name = "Armor design ([item_name])"
+
 /datum/design/armor/rt
 	name = "Improved RT Cloak"
 	id = "rtcloak"
@@ -2012,7 +2017,7 @@ A reminder that mechanicus cannot remove their armor for a majority of their rol
 	build_path = /obj/item/clothing/suit/armor/guardsman/mechanicus
 	sort_string = "XCAH"
 
-/datum/design/armor/carace/guard
+/datum/design/armor/carapace/guard
 	name = "Improved Cadian Carapace Armor"
 	id = "guardcara"
 	req_tech = list(TECH_MATERIAL = 6, TECH_ENGINEERING = 6, TECH_COMBAT = 8)


### PR DESCRIPTION
Fixed armor production - it should be able to produced through the Protolathe, as soon as the necessary tech levels are met. It will also highlight which items are armor, as per standard notation so far.

This should make the AdMech much more of a supply-and-support faction.